### PR TITLE
Created Scene Node to account for different layers and relative coordinates

### DIFF
--- a/Sfml-Game-Development/Header/Aircraft.h
+++ b/Sfml-Game-Development/Header/Aircraft.h
@@ -1,0 +1,26 @@
+#ifndef AIRCRAFT_H
+#define AIRCRAFT_H
+
+#include "Entity.h"
+#include "ResourceHolder.hpp"
+#include "ResourceIdentifiers.h"
+
+class Aircraft : public Entity
+{
+public:
+	enum class Type : int {
+		Eagle, 
+		Raptor
+	};
+
+	explicit Aircraft(Type type, const ResourceHolder<sf::Texture, Textures::ID>& textures);
+
+	virtual void drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const;
+
+private:
+	Type mType;
+	sf::Sprite mSprite;
+};
+
+#endif
+

--- a/Sfml-Game-Development/Header/Entity.h
+++ b/Sfml-Game-Development/Header/Entity.h
@@ -1,0 +1,21 @@
+#ifndef ENTITY_H
+#define ENTITY_H
+
+#include <SFML/Graphics.hpp>
+#include "SceneNode.h"
+
+class Entity : public SceneNode
+{
+public:
+	void setVelocity(sf::Vector2f velocity);
+	void setVelocity(float vx, float vy);
+	sf::Vector2f getVelocity() const;
+
+private:
+	virtual void updateCurrent(sf::Time dt);
+
+	sf::Vector2f mVelocity;
+};
+
+#endif
+

--- a/Sfml-Game-Development/Header/ResourceHolder.hpp
+++ b/Sfml-Game-Development/Header/ResourceHolder.hpp
@@ -7,23 +7,6 @@
 #include <string>
 #include <stdexcept>
 
-namespace Textures
-{
-	enum class ID : int
-	{
-		Landscape,
-		Airplane,
-		Missile
-	};
-}
-
-namespace Fonts
-{
-	enum class ID : int
-	{
-		Sansation
-	};
-}
 
 template <typename Resource, typename Identifier>
 class ResourceHolder

--- a/Sfml-Game-Development/Header/ResourceIdentifiers.h
+++ b/Sfml-Game-Development/Header/ResourceIdentifiers.h
@@ -1,0 +1,37 @@
+#ifndef RESOURCEIDENTIFIERS_H
+#define RESOURCEIDENTIFIERS_H
+
+// Forward declaration
+namespace sf
+{
+	class Font;
+	class Texture;
+}
+
+
+namespace Textures
+{
+	enum class ID : int
+	{
+		Eagle,
+		Raptor
+	};
+}
+
+namespace Fonts
+{
+	enum class ID : int
+	{
+		Sansation
+	};
+}
+
+// Forward declaration and a few type definitions
+template <typename Resource, typename Identifier>
+class ResourceHolder;
+
+typedef ResourceHolder<sf::Font, Fonts::ID> FontHolder;
+typedef ResourceHolder<sf::Texture, Textures::ID> TextureHolder;
+
+
+#endif

--- a/Sfml-Game-Development/Header/SceneNode.h
+++ b/Sfml-Game-Development/Header/SceneNode.h
@@ -1,0 +1,46 @@
+#ifndef SCENENODE_H
+#define SCENENODE_H
+
+#include <memory>
+#include <vector>
+#include <cassert>
+#include <SFML/Graphics.hpp>
+
+class SceneNode : public sf::Drawable, public sf::Transformable
+{
+public:
+	typedef std::unique_ptr<SceneNode> Ptr;
+
+	SceneNode();
+
+	// Non copyable
+	SceneNode(const SceneNode&) = delete;
+	SceneNode& operator=(SceneNode&) = delete;
+
+	void attachChild(Ptr child);
+
+	Ptr detachChild(const SceneNode& node);
+
+	void update(sf::Time dt);
+
+	sf::Transform getWorldTransform() const;
+
+	sf::Vector2f getWorldPosition() const;
+
+private:
+	virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const;
+
+	virtual void drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const;
+
+	void drawChildren(sf::RenderTarget& target, sf::RenderStates states) const;
+
+	virtual void updateCurrent(sf::Time dt);
+
+	void updateChildren(sf::Time dt);
+
+	std::vector<Ptr> mChildren;
+	SceneNode* mParent;
+};
+
+#endif
+

--- a/Sfml-Game-Development/Header/World.h
+++ b/Sfml-Game-Development/Header/World.h
@@ -1,0 +1,17 @@
+#ifndef WORLD_H
+#define WORLD_H
+
+class World
+{
+public:
+
+
+private:
+	enum class Layer {
+		Background,
+		Air,
+		LayerCount
+	};
+};
+
+#endif

--- a/Sfml-Game-Development/Main.cpp
+++ b/Sfml-Game-Development/Main.cpp
@@ -1,16 +1,16 @@
 #include "Header/ResourceHolder.hpp"
+#include "Header/ResourceIdentifiers.h"
 #include <SFML/Graphics.hpp>
 
 int main()
 {
-	ResourceHolder <sf::Texture, Textures::ID> textures;
-	textures.load(Textures::ID::Airplane, "Media/Textures/Eagle.png");
-
-	sf::Sprite playerPlane(textures.get(Textures::ID::Airplane));
+	TextureHolder textures;
+	textures.load(Textures::ID::Eagle, "Media/Textures/Eagle.png");
+	sf::Sprite playerPlane(textures.get(Textures::ID::Eagle));
 
 	sf::RenderWindow window(sf::VideoMode({ 640, 480 }), "SFML Application", sf::Style::Close);
 	
-	ResourceHolder <sf::Font, Fonts::ID> fonts;
+	FontHolder fonts;
 	fonts.open(Fonts::ID::Sansation, "Media/Sansation.ttf");
 	sf::Text text(fonts.get(Fonts::ID::Sansation), "Hello");
 	text.setPosition({ 200.f, 200.f });

--- a/Sfml-Game-Development/Source/Aircraft.cpp
+++ b/Sfml-Game-Development/Source/Aircraft.cpp
@@ -1,0 +1,27 @@
+#include "../Header/Aircraft.h"
+
+Textures::ID toTextureID(Aircraft::Type type)
+{
+	switch (type) 
+	{
+	case Aircraft::Type::Eagle:
+		return Textures::ID::Eagle;
+
+	case Aircraft::Type::Raptor:
+		return Textures::ID::Raptor;
+	}
+
+	return Textures::ID::Eagle;
+}
+
+Aircraft::Aircraft(Type type, const ResourceHolder<sf::Texture, Textures::ID>& textures): 
+	mType(type), mSprite(textures.get(toTextureID(type))) 
+{
+	sf::FloatRect origin = mSprite.getLocalBounds();
+	mSprite.setOrigin(origin.getCenter());
+}
+
+void Aircraft::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const 
+{
+	target.draw(mSprite, states);
+}

--- a/Sfml-Game-Development/Source/Entity.cpp
+++ b/Sfml-Game-Development/Source/Entity.cpp
@@ -1,0 +1,23 @@
+#include "../Header/Entity.h"
+
+void Entity::setVelocity(sf::Vector2f velocity) 
+{
+	mVelocity = velocity;
+}
+
+void Entity::setVelocity(float vx, float vy) 
+{
+	mVelocity.x = vx;
+	mVelocity.y = vy;
+}
+
+sf::Vector2f Entity::getVelocity() const 
+{
+	return mVelocity;
+}
+
+void Entity::updateCurrent(sf::Time dt)
+{
+	move(mVelocity * dt.asSeconds());
+}
+

--- a/Sfml-Game-Development/Source/SceneNode.cpp
+++ b/Sfml-Game-Development/Source/SceneNode.cpp
@@ -1,0 +1,78 @@
+#include "../Header/SceneNode.h"
+
+SceneNode::SceneNode() 
+	: mChildren()
+, mParent(nullptr) {}
+
+
+void SceneNode::attachChild(Ptr child) 
+{
+	child->mParent = this;
+	mChildren.push_back(std::move(child));
+}
+
+SceneNode::Ptr SceneNode::detachChild(const SceneNode& node) 
+{
+	auto found = std::find_if(mChildren.begin(), mChildren.end(), 
+		[&](Ptr& p) -> bool { return p.get() == &node; });
+
+	assert(found != mChildren.end());
+
+	Ptr result = std::move(*found);
+	result->mParent = nullptr;
+	mChildren.erase(found);
+	return result;
+}
+
+void SceneNode::update(sf::Time dt) 
+{
+	updateCurrent(dt);
+	updateChildren(dt);
+}
+
+sf::Transform SceneNode::getWorldTransform() const 
+{
+	sf::Transform transform = sf::Transform::Identity;
+	for (const SceneNode* node = this; node != nullptr; node = node->mParent) 
+	{ // For Matrix Mulitplication, AB != BA and need to multiply starting from root
+		transform = node->getTransform() * transform;
+	}
+
+	return transform;
+}
+
+sf::Vector2f SceneNode::getWorldPosition() const {
+	return getWorldTransform() * sf::Vector2f();
+}
+
+void SceneNode::draw(sf::RenderTarget& target, sf::RenderStates states) const 
+{
+	states.transform *= getTransform();
+
+	drawCurrent(target, states);
+	drawChildren(target, states);
+}
+
+void SceneNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const 
+{}
+
+void SceneNode::drawChildren(sf::RenderTarget& target, sf::RenderStates states) const
+{
+	for (const Ptr& child : mChildren)
+	{
+		child->draw(target, states);
+	}
+}
+
+void SceneNode::updateCurrent(sf::Time dt) 
+{}
+
+
+void SceneNode::updateChildren(sf::Time dt) 
+{
+	for (Ptr& child : mChildren) {
+		child->update(dt);
+	}
+}
+
+


### PR DESCRIPTION
### Layers
- In a game, there are layers, which are the orders to draw first. This is accounted for by Layer in World.

### Relative Coordinates
- Sometimes, the transformation must depend on other objects. This is why the SceneNode's update and draw use relative coordinates.

### Absolute Coordinates
- Collision detection should use absolute coordinates to discover the object's exact location.
- The sf::Transform is a 3 by 3 matrix that holds the transformation and translation data.

### std::unique_ptr
- unique_ptrs contain the idea of single ownership, and the objects can't have a cycle of unique_ptrs.