### PR TITLE
Network to allow Multiplayer Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Sfml-Game-Development/sfml-system-3.dll
 Sfml-Game-Development/sfml-graphics-3.dll
 Sfml-Game-Development/sfml-audio-3.dll
 Sfml-Game-Development/sfml-network-3.dll
+ip.txt

--- a/Sfml-Game-Development/Header/Aircraft.h
+++ b/Sfml-Game-Development/Header/Aircraft.h
@@ -28,6 +28,7 @@ public:
 	virtual bool isMarkedForRemoval() const;
 	bool isAllied() const;
 	float getMaxSpeed() const;
+	void disablePickups();
 
 	void increaseSpread();
 	void increaseFireRate();
@@ -36,6 +37,10 @@ public:
 	void fire();
 	void launchMissile();
 	void playLocalSound(CommandQueue& commands, SoundEffect::ID effect);
+	int32_t getIdentifier();
+	void setIdentifier(int32_t identifier);
+	int32_t getMissileAmmo() const;
+	void setMissileAmmo(int ammo);
 
 private:
 	virtual void drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const;
@@ -64,17 +69,20 @@ private:
 	bool mIsFiring;
 	bool mIsLaunchingMissile;
 	bool mShowExplosion;
-	bool mPlayedExplosionSound;
+	bool mExplosionBegan;
 	bool mSpawnedPickup;
+	bool mPickupsEnabled;
 
 	int mFireRateLevel;
 	int mSpreadLevel;
-	int mMissileAmmo;
+	int32_t mMissileAmmo;
 
 	float mTravelledDistance;
 	size_t mDirectionIndex;
 	TextNode* mHealthDisplay;
 	TextNode* mMissileDisplay;
+
+	int32_t mIdentifier;
 };
 
 #endif

--- a/Sfml-Game-Development/Header/Application.h
+++ b/Sfml-Game-Development/Header/Application.h
@@ -3,7 +3,7 @@
 
 #include "ResourceHolder.hpp"
 #include "ResourceIdentifiers.h"
-#include "Player.h"
+#include "KeyBinding.h"
 #include "StateStack.h"
 #include "Utility.hpp"
 
@@ -15,6 +15,7 @@
 #include "PauseState.h"
 #include "SettingsState.h"
 #include "GameOverState.h"
+#include "MultiplayerGameState.h"
 #include "SoundPlayer.h"
 #include "MusicPlayer.h"
 
@@ -49,10 +50,11 @@ private:
 	sf::RenderWindow mWindow;
 	TextureHolder mTextures;
 	FontHolder& mFonts;
-	Player mPlayer;
-
 	SoundPlayer mSounds;
 	MusicPlayer mMusic;
+
+	KeyBinding mKeyBinding1;
+	KeyBinding mKeyBinding2;
 	StateStack mStateStack;
 	
 	sf::Text mStatisticsText;

--- a/Sfml-Game-Development/Header/Category.h
+++ b/Sfml-Game-Development/Header/Category.h
@@ -15,6 +15,7 @@ namespace Category
 		EnemyProjectile = 1 << 6,
 		ParticleSystem = 1 << 7,
 		SoundEffect = 1 << 8,
+		Network = 1 << 9,
 
 		Aircraft = PlayerAircraft | AlliedAircraft | EnemyAircraft,
 		Projectile = AlliedProjectile | EnemyProjectile,

--- a/Sfml-Game-Development/Header/Entity.h
+++ b/Sfml-Game-Development/Header/Entity.h
@@ -16,6 +16,7 @@ public:
 	sf::Vector2f getVelocity() const;
 
 	int getHitpoints() const;
+	void setHitpoints(int points);
 	void repair(int points);
 	void damage(int points);
 	void destroy();

--- a/Sfml-Game-Development/Header/GameOverState.h
+++ b/Sfml-Game-Development/Header/GameOverState.h
@@ -10,7 +10,7 @@
 class GameOverState : public State
 {
 public:
-	GameOverState(StateStack& stack, Context context);
+	GameOverState(StateStack& stack, Context context, const std::string& text);
 
 	virtual void draw();
 	virtual bool update(sf::Time dt);

--- a/Sfml-Game-Development/Header/GameServer.h
+++ b/Sfml-Game-Development/Header/GameServer.h
@@ -1,0 +1,97 @@
+#ifndef GAME_SERVER_H
+#define GAME_SERVER_H
+
+#include <SFML/System/Vector2.hpp>
+#include <SFML/System/Clock.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/Network/TcpListener.hpp>
+#include <SFML/Network/TcpSocket.hpp>
+
+#include <thread>
+#include <map>
+#include <memory>
+#include <vector>
+#include <mutex>
+#include <condition_variable>
+
+
+class GameServer
+{
+public:
+	explicit GameServer(sf::Vector2f battlefieldSize);
+	~GameServer();
+
+private:
+	struct RemotePeer
+	{
+		RemotePeer();
+
+		sf::TcpSocket socket;
+		sf::Time lastPacketTime;
+		std::vector<int32_t> aircraftIdentifiers;
+		bool ready;
+		bool timedOut;
+	};
+
+	struct AircraftInfo
+	{
+		sf::Vector2f position;
+		int32_t hitpoints;
+		int32_t missileAmmo;
+		std::map<int32_t, bool> realtimeActions;
+	};
+
+	typedef std::unique_ptr<RemotePeer> PeerPtr;
+
+	void notifyPlayerSpawn(int32_t aircraftIdentifier);
+	void notifyPlayerRealtimeChange(int32_t aircraftIdentifier,
+		int32_t action, bool actionEnabled, const RemotePeer& changer);
+	void nofifyPlayerEvent(int32_t aircraftIdentifier, int32_t action);
+
+	void setListening(bool enable);
+	void executionThread();
+	void tick();
+
+	sf::Time now() const;
+	void handleIncomingPackets();
+	void handleIncomingPacket(sf::Packet& packet,
+		RemotePeer& receivingPeer, bool& detectedTimeout);
+
+	void handleIncomingConnections();
+	void handleDisconnections();
+
+	void informWorldState(sf::TcpSocket& socket);
+	void broadcastMessage(const std::string& message);
+	void sendToAll(sf::Packet& packet);
+	void updateClientState();
+
+	std::thread mThread;
+	sf::Clock mClock;
+	sf::TcpListener mListenerSocket;
+	bool mListeningState;
+	sf::Time mClientTimeoutTime;
+
+	size_t mMaxConnectedPlayers;
+	size_t mConnectedPlayers;
+
+	float mWorldHeight;
+	sf::FloatRect mBattleFieldRect;
+	float mBattleFieldScrollSpeed;
+
+	size_t mAircraftCount;
+	std::map<int32_t, AircraftInfo> mAircraftInfo;
+
+	std::vector<PeerPtr> mPeers;
+	int32_t mAircraftIdentifierCounter;
+	bool mWaitingThreadEnd;
+
+	sf::Time mLastSpawnTime;
+	sf::Time mTimeForNextSpawn;
+
+	std::mutex mInitMutex;
+	std::condition_variable mInitCondition;
+	bool mInitComplete = false;
+};
+
+#endif
+

--- a/Sfml-Game-Development/Header/GameState.h
+++ b/Sfml-Game-Development/Header/GameState.h
@@ -19,7 +19,7 @@ public:
 
 private:
 	World mWorld;
-	Player& mPlayer;
+	Player mPlayer;
 };
 
 #endif

--- a/Sfml-Game-Development/Header/KeyBinding.h
+++ b/Sfml-Game-Development/Header/KeyBinding.h
@@ -1,0 +1,43 @@
+#ifndef KEY_BINDING_H
+#define KEY_BINDING_H
+
+#include <SFML/Window/Keyboard.hpp>
+#include <vector>
+#include <map>
+
+namespace PlayerAction
+{
+	enum Type
+	{
+		MoveLeft,
+		MoveRight,
+		MoveUp,
+		MoveDown,
+		Fire,
+		LaunchMissile,
+		Count
+	};
+}
+
+class KeyBinding
+{
+public:
+	typedef PlayerAction::Type Action;
+
+	// controlPreconfiguration notes whether the player is 1 or 2
+	explicit KeyBinding(int controlPreconfiguration);
+
+	void assignKey(Action action, sf::Keyboard::Key key);
+	sf::Keyboard::Key getAssignedKey(Action action) const;
+
+	bool checkAction(sf::Keyboard::Key key, Action& out) const;
+	std::vector<Action> getRealtimeActions() const;
+
+private:
+	std::map<sf::Keyboard::Key, Action> mKeyMap;
+};
+
+bool isRealtimeAction(PlayerAction::Type action);
+
+#endif
+

--- a/Sfml-Game-Development/Header/MultiplayerGameState.h
+++ b/Sfml-Game-Development/Header/MultiplayerGameState.h
@@ -1,0 +1,64 @@
+#ifndef MULTIPLAYER_GAMESTATE_H
+#define MULTIPLAYER_GAMESTATE_H
+
+#include "State.h"
+#include "World.h"
+#include "Player.h"
+#include "GameServer.h"
+#include "NetworkProtocol.h"
+
+#include <SFML/System/Clock.hpp>
+#include <SFML/Graphics/Text.hpp>
+#include <SFML/Network/TcpSocket.hpp>
+#include <SFML/Network/Packet.hpp>
+
+// Client
+class MultiplayerGameState : public State
+{
+public:
+	MultiplayerGameState(StateStack& stack, Context context, bool isHost);
+
+	virtual void draw();
+	virtual bool update(sf::Time dt);
+	virtual bool handleEvent(const sf::Event& event);
+	virtual void onActivate();
+	void onDestroy();
+
+	void disableAllRealtimeActions();
+
+private:
+	void updateBroadcastMessage(sf::Time elapsedTime);
+	void handlePacket(int32_t packetType, sf::Packet& packet);
+
+	typedef std::unique_ptr<Player> PlayerPtr;
+
+	World mWorld;
+	sf::RenderWindow& mWindow;
+	TextureHolder& mTextureHolder;
+
+	std::map<int32_t, PlayerPtr> mPlayers;
+	std::vector<int32_t> mLocalPlayerIdentifiers;
+	sf::TcpSocket mSocket;
+	bool mConnected;
+	std::unique_ptr<GameServer> mGameServer;
+	sf::Clock mTickClock;
+
+	std::vector<std::string> mBroadcasts;
+	sf::Text mBroadcastText;
+	sf::Time mBroadcastElapsedTime;
+
+	sf::Text mPlayerInvitationText;
+	sf::Time mPlayerInvitationTime;
+
+	sf::Text mFailedConnectionText;
+	sf::Clock mFailedConnectionClock;
+
+	bool mActiveState;
+	bool mHasFocus;
+	bool mHost;
+	bool mGameStarted;
+	sf::Time mClientTimeout;
+	sf::Time mTimeSinceLastPacket;
+};
+
+#endif

--- a/Sfml-Game-Development/Header/NetworkNode.h
+++ b/Sfml-Game-Development/Header/NetworkNode.h
@@ -1,0 +1,24 @@
+#ifndef NETWORK_NODE_H
+#define NETWORK_NODE_H
+
+#include "SceneNode.h"
+#include "NetworkProtocol.h"
+
+#include <queue>
+
+class NetworkNode : public SceneNode
+{
+public:
+	NetworkNode();
+
+	void notifyGameAction(GameActions::Type type, sf::Vector2f position);
+	bool pollGameAction(GameActions::Action& out);
+
+	virtual unsigned int getCategory() const;
+
+private:
+	std::queue<GameActions::Action> mPendingActions;
+};
+
+#endif
+

--- a/Sfml-Game-Development/Header/NetworkProtocol.h
+++ b/Sfml-Game-Development/Header/NetworkProtocol.h
@@ -1,0 +1,80 @@
+#ifndef NETWORK_PROTOCOL_H
+#define NETWORK_PROTOCOL_H
+
+#include <SFML/Config.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+const unsigned short ServerPort = 5001;
+
+namespace Server
+{ // Packets originated in the server beginning with int32_t packetType
+	enum PacketType
+	{
+		BroadcastMessage,
+		SpawnSelf,
+		InitialState,
+		PlayerEvent,
+		PlayerRealtimeChange,
+		PlayerConnect,
+		PlayerDisconnect,
+		AcceptCoopPartner,
+		SpawnEnemy,
+		SpawnPickup,
+		UpdateClientState,
+		MissionSuccess
+	};
+}
+
+namespace Client
+{ // Packets originated in the client beginning with int32_t packetType
+	enum PacketType
+	{
+		PlayerEvent,
+		PlayerRealtimeChange,
+		RequestCoopPartner,
+		PositionUpdate,
+		GameEvent,
+		Quit
+	};
+}
+
+namespace PlayerActions
+{
+	enum Action
+	{
+		MoveLeft,
+		MoveRight,
+		MoveUp,
+		MoveDown,
+		Fire,
+		LaunchMissile,
+		ActionCount
+	};
+}
+
+namespace GameActions
+{
+	enum Type
+	{
+		EnemyExplode,
+	};
+
+	struct Action
+	{
+		Action()
+		{ 
+		}
+
+		Action(Type type, sf::Vector2f position)
+			: type(type)
+			, position(position)
+		{
+		}
+
+		Type type;
+		sf::Vector2f position;
+	};
+}
+
+#endif

--- a/Sfml-Game-Development/Header/PauseState.h
+++ b/Sfml-Game-Development/Header/PauseState.h
@@ -13,7 +13,7 @@
 class PauseState : public State
 {
 public:
-	PauseState(StateStack& stack, Context context);
+	PauseState(StateStack& stack, Context context, bool letUpdatesThrough = false);
 	~PauseState();
 
 	virtual void draw();
@@ -23,6 +23,7 @@ public:
 private:
 	sf::Text mPauseText;
 	GUI::Container mGUIContainer;
+	bool mLetUpdatesThrough;
 };
 
 #endif

--- a/Sfml-Game-Development/Header/Player.h
+++ b/Sfml-Game-Development/Header/Player.h
@@ -9,7 +9,7 @@
 
 #include <map>
 
-// To Delete: Used to include CommandQueue
+
 class CommandQueue;
 
 class Player

--- a/Sfml-Game-Development/Header/SettingsState.h
+++ b/Sfml-Game-Development/Header/SettingsState.h
@@ -20,12 +20,12 @@ public:
 
 private:
 	void updateLabels();
-	void addButtonLabel(Player::Action action, float y, const std::string& text, Context context);
+	void addButtonLabel(size_t index, size_t x, size_t y, const std::string& text, Context context);
 
 	sf::Sprite mBackgroundSprite;
 	GUI::Container mGUIContainer;
-	std::array<GUI::Button::Ptr, Player::ActionCount> mBindingButtons;
-	std::array<GUI::Label::Ptr, Player::ActionCount> mBindingLabels;
+	std::array<GUI::Button::Ptr, 2 * PlayerAction::Count> mBindingButtons;
+	std::array<GUI::Label::Ptr, 2 * PlayerAction::Count> mBindingLabels;
 };
 
 #endif

--- a/Sfml-Game-Development/Header/SoundPlayer.h
+++ b/Sfml-Game-Development/Header/SoundPlayer.h
@@ -23,7 +23,7 @@ public:
 	void play(SoundEffect::ID effect);
 	void play(SoundEffect::ID effect, sf::Vector2f position);
 
-	void removeSounds();
+	void removeStoppedSounds();
 	void setListenerPosition(sf::Vector2f position);
 	sf::Vector2f getListenerPosition() const;
 

--- a/Sfml-Game-Development/Header/State.h
+++ b/Sfml-Game-Development/Header/State.h
@@ -16,9 +16,9 @@ namespace sf
 }
 
 class StateStack;
-class Player;
 class MusicPlayer;
 class SoundPlayer;
+class KeyBinding;
 
 class State
 {
@@ -28,14 +28,15 @@ public:
 	struct Context
 	{
 		Context(sf::RenderWindow& window, TextureHolder& textures, FontHolder& fonts, 
-			Player& player, MusicPlayer& music, SoundPlayer& sounds);
+			MusicPlayer& music, SoundPlayer& sounds, KeyBinding& keys1, KeyBinding& keys2);
 		
 		sf::RenderWindow* window;
 		TextureHolder* textures;
 		FontHolder* fonts;
-		Player* player;
 		MusicPlayer* music;
 		SoundPlayer* sounds;
+		KeyBinding* keys1;
+		KeyBinding* keys2;
 	};
 
 	State(StateStack& stack, Context context);
@@ -44,6 +45,9 @@ public:
 	virtual void draw() = 0;
 	virtual bool update(sf::Time dt) = 0;
 	virtual bool handleEvent(const sf::Event& event) = 0;
+
+	virtual void onActivate();
+	virtual void onDestroy();
 
 protected:
 	void requestStackPush(States::ID stateID);

--- a/Sfml-Game-Development/Header/StateIdentifiers.h
+++ b/Sfml-Game-Development/Header/StateIdentifiers.h
@@ -10,8 +10,12 @@ namespace States
 		Menu,
 		Game,
 		Pause,
+		NetworkPause,
 		Settings,
 		GameOver,
+		MissionSuccess,
+		HostGame,
+		JoinGame,
 	};
 }
 

--- a/Sfml-Game-Development/Header/StateStack.h
+++ b/Sfml-Game-Development/Header/StateStack.h
@@ -39,6 +39,9 @@ public:
 	template <typename T>
 	void registerState(States::ID stateID);
 
+	template <typename T, typename Param1>
+	void registerState(States::ID stateID, Param1 arg1);
+
 	void update(sf::Time dt);
 	void draw();
 	void handleEvent(const sf::Event& event);
@@ -74,6 +77,15 @@ void StateStack::registerState(States::ID stateID)
 	mFactories[stateID] = [this]()
 		{
 			return State::Ptr(new T(*this, mContext));
+		};
+}
+
+template <typename T, typename Param1>
+void StateStack::registerState(States::ID stateID, Param1 arg1)
+{
+	mFactories[stateID] = [this, arg1]()
+		{
+			return State::Ptr(new T(*this, mContext, arg1));
 		};
 }
 

--- a/Sfml-Game-Development/Source/Application.cpp
+++ b/Sfml-Game-Development/Source/Application.cpp
@@ -11,10 +11,12 @@ Application::Application(FontHolder& fonts)
 	: mWindow(sf::VideoMode({ 1024, 768 }), "States", sf::Style::Close)
 	, mTextures()
 	, mFonts(fonts)
-	, mPlayer()
 	, mSounds()
 	, mMusic()
-	, mStateStack(State::Context(mWindow, mTextures, mFonts, mPlayer, mMusic, mSounds))
+	, mKeyBinding1(1)
+	, mKeyBinding2(2)
+	, mStateStack(State::Context(mWindow, mTextures, mFonts, mMusic, mSounds, 
+		mKeyBinding1, mKeyBinding2))
 	, mStatisticsText(fonts.get(Fonts::ID::Sansation))
 	, mStatisticsUpdateTime(sf::Time::Zero)
 	, mStatisticsNumFrames(0)
@@ -113,6 +115,10 @@ void Application::registerStates()
 	mStateStack.registerState<MenuState>(States::Menu);
 	mStateStack.registerState<GameState>(States::Game);
 	mStateStack.registerState<PauseState>(States::Pause);
+	mStateStack.registerState<PauseState>(States::NetworkPause, true);
 	mStateStack.registerState<SettingsState>(States::Settings);
-	mStateStack.registerState<GameOverState>(States::GameOver);
+	mStateStack.registerState<GameOverState>(States::GameOver, "Mission failed!");
+	mStateStack.registerState<GameOverState>(States::MissionSuccess, "Mission successful!");
+	mStateStack.registerState<MultiplayerGameState>(States::HostGame, true);
+	mStateStack.registerState<MultiplayerGameState>(States::JoinGame, false);
 }

--- a/Sfml-Game-Development/Source/Entity.cpp
+++ b/Sfml-Game-Development/Source/Entity.cpp
@@ -40,6 +40,12 @@ int Entity::getHitpoints() const
 	return mHitpoints;
 }
 
+void Entity::setHitpoints(int points)
+{
+	assert(points > 0);
+	mHitpoints = points;
+}
+
 void Entity::repair(int points)
 {
 	assert(points > 0);

--- a/Sfml-Game-Development/Source/GameOverState.cpp
+++ b/Sfml-Game-Development/Source/GameOverState.cpp
@@ -8,11 +8,9 @@
 #include <SFML/Graphics/View.hpp>
 
 
-GameOverState::GameOverState(StateStack& stack, Context context)
+GameOverState::GameOverState(StateStack& stack, Context context, const std::string& text)
 	: State(stack, context)
-	, mGameOverText(context.fonts->get(Fonts::ID::Sansation), 
-		State::getContext().player->getMissionStatus() == Player::MissionSuccess ? 
-		"Mission successful!" : "Mission failed!", 70)
+	, mGameOverText(context.fonts->get(Fonts::ID::Sansation), text, 70)
 	, mElapsedTime(sf::Time::Zero)
 {
 	centerOrigin(mGameOverText);

--- a/Sfml-Game-Development/Source/GameServer.cpp
+++ b/Sfml-Game-Development/Source/GameServer.cpp
@@ -1,0 +1,538 @@
+#include "../Header/GameServer.h"
+#include "../Header/NetworkProtocol.h"
+#include "../Header/Pickup.h"
+#include "../Header/Aircraft.h" 
+
+#include <SFML/Network/Packet.hpp>
+#include <iostream>
+
+
+GameServer::RemotePeer::RemotePeer()
+	: socket()
+	, lastPacketTime(sf::Time::Zero)
+	, aircraftIdentifiers()
+	, ready(false)
+	, timedOut(false)
+{
+	socket.setBlocking(false);
+}
+
+GameServer::GameServer(sf::Vector2f battlefieldSize)
+	: mThread(&GameServer::executionThread, this)
+	, mClock()
+	, mListenerSocket()
+	, mListeningState(false)
+	, mClientTimeoutTime(sf::seconds(3.f))
+	, mMaxConnectedPlayers(10)
+	, mConnectedPlayers(0)
+	, mWorldHeight(5000.f)
+	, mBattleFieldRect({0.f, mWorldHeight - battlefieldSize.y}, battlefieldSize)
+	, mBattleFieldScrollSpeed(-50.f)
+	, mAircraftCount(0)
+	, mAircraftInfo()
+	, mPeers(1)
+	, mAircraftIdentifierCounter(1)
+	, mWaitingThreadEnd(false)
+	, mLastSpawnTime(sf::Time::Zero)
+	, mTimeForNextSpawn(sf::seconds(5.f))
+	, mInitMutex()
+	, mInitCondition()
+	, mInitComplete(false)
+{
+	{
+		std::unique_lock<std::mutex> lock(mInitMutex);
+
+		mListenerSocket.setBlocking(false);
+		mPeers[0].reset(new RemotePeer());
+
+		mInitComplete = true;
+	}
+
+	mInitCondition.notify_one();
+}
+
+GameServer::~GameServer()
+{ 
+	mWaitingThreadEnd = true;
+	mThread.join();
+}
+
+void GameServer::notifyPlayerSpawn(int32_t aircraftIdentifier)
+{ 
+	sf::Packet packet;
+	packet << static_cast<int32_t>(Server::PlayerConnect);
+	packet << aircraftIdentifier 
+		<< mAircraftInfo[aircraftIdentifier].position.x
+		<< mAircraftInfo[aircraftIdentifier].position.y;
+
+	sendToAll(packet);
+}
+
+void GameServer::notifyPlayerRealtimeChange(int32_t aircraftIdentifier,
+	int32_t action, bool actionEnabled, const RemotePeer& changer)
+{ 
+	sf::Packet packet;
+	packet << static_cast<int32_t> (Server::PlayerRealtimeChange)
+		<< aircraftIdentifier << action << actionEnabled;
+
+	for (auto& peer : mPeers)
+	{
+		if (peer->ready && peer.get() != &changer)
+		{
+			peer->socket.send(packet);
+		}
+	}
+}
+
+void GameServer::nofifyPlayerEvent(int32_t aircraftIdentifier, int32_t action)
+{ 
+	sf::Packet packet;
+	packet << static_cast<int32_t> (Server::PlayerEvent);
+	packet << aircraftIdentifier << action;
+	sendToAll(packet);
+}
+
+void GameServer::setListening(bool enable)
+{ 
+	if (enable)
+	{
+		if (!mListeningState)
+		{
+			mListeningState = 
+				(mListenerSocket.listen(ServerPort) == sf::TcpListener::Status::Done);
+		}
+	}
+	else
+	{
+		mListenerSocket.close();
+		mListeningState = false;
+	}
+}
+
+void GameServer::executionThread()
+{ 
+	{
+		std::unique_lock<std::mutex> lock(mInitMutex);
+		mInitCondition.wait(lock, [this] { return mInitComplete; });
+	}
+
+	setListening(true);
+
+	sf::Time stepInterval = sf::seconds(1.f / 60.f);
+	sf::Time stepTime = sf::Time::Zero;
+	sf::Time tickInterval = sf::seconds(1.f / 20.f);
+	sf::Time tickTime = sf::Time::Zero;
+
+	sf::Clock clock;
+	while (!mWaitingThreadEnd)
+	{
+		handleIncomingPackets();
+		handleIncomingConnections();
+
+		sf::Time dt = clock.getElapsedTime();
+		clock.restart();
+
+		stepTime += dt;
+		tickTime += dt;
+
+		while (stepTime >= stepInterval)
+		{
+			mBattleFieldRect.position.y += mBattleFieldScrollSpeed * stepInterval.asSeconds();
+			stepTime -= stepInterval;
+		}
+
+		while (tickTime >= tickInterval)
+		{
+			tick();
+			tickTime -= tickInterval;
+		}
+
+		sf::sleep(sf::milliseconds(1));
+	}
+}
+
+void GameServer::tick()
+{ 
+	// Server::UpdateClientState
+	updateClientState();
+
+	// Server::MissionSuccess
+	bool success = true;
+	bool allDestroyed = true;
+	for (auto pair : mAircraftInfo)
+	{
+		allDestroyed = false;
+
+		if (pair.second.position.y > 0.f)
+		{
+			success = false;
+		}
+	}
+
+	if (!allDestroyed && success)
+	{
+		sf::Packet successPacket;
+		successPacket << static_cast<int32_t> (Server::MissionSuccess);
+		sendToAll(successPacket);
+	}
+
+	// Remove destroyed aircraft (Position matters more than HP)
+	for (auto itr = mAircraftInfo.begin(); itr != mAircraftInfo.end();)
+	{
+		if (itr->second.hitpoints <= 0)
+		{
+			itr = mAircraftInfo.erase(itr);
+		}
+		else
+		{
+			++itr;
+		}
+	}
+
+	// Server::SpawnEnemy
+	if (now() >= mLastSpawnTime + mTimeForNextSpawn)
+	{
+		if (mBattleFieldRect.position.y > 600.f)
+		{
+			size_t enemyCount = 1u + rand() % 2;
+			float spawnCenterX = static_cast<float> (rand() % 500 - 250);
+
+			// Choose enemy type and position and send them
+			float planeDistance = 0.f;
+			float nextSpawnX = spawnCenterX;
+
+			if (enemyCount == 2)
+			{
+				planeDistance = static_cast<float> (150 + rand() % 250);
+				nextSpawnX = spawnCenterX - planeDistance / 2.f;
+			}
+
+			for (size_t i = 0; i < enemyCount; ++i)
+			{
+				sf::Packet enemyPacket;
+				enemyPacket << static_cast<int32_t>(Server::SpawnEnemy)
+					<< static_cast<int32_t>(1 + rand() % (Aircraft::TypeCount - 1))
+					<< mWorldHeight - mBattleFieldRect.position.y + 500
+					<< nextSpawnX;
+
+				nextSpawnX += planeDistance;
+
+				sendToAll(enemyPacket);
+			}
+			
+			mLastSpawnTime = now();
+			mTimeForNextSpawn = sf::milliseconds(2000 + rand() % 6000);
+		}
+	}
+}
+
+sf::Time GameServer::now() const
+{
+	return mClock.getElapsedTime();
+}
+
+void GameServer::handleIncomingPackets()
+{
+	bool detectedTimeOut = false;
+
+	for (PeerPtr& peer : mPeers)
+	{
+		if (peer->ready)
+		{
+			sf::Packet packet;
+			while (peer->socket.receive(packet) == sf::TcpSocket::Status::Done)
+			{
+				handleIncomingPacket(packet, *peer, detectedTimeOut);
+
+				peer->lastPacketTime = now();
+				packet.clear();
+			}
+			
+			if (peer->lastPacketTime + mClientTimeoutTime <= now())
+			{
+				detectedTimeOut = true;
+				peer->timedOut = true;
+			}
+		}
+	}
+
+	if (detectedTimeOut)
+	{
+		handleDisconnections();
+	}
+}
+
+void GameServer::handleIncomingPacket(sf::Packet& packet,
+	RemotePeer& receivingPeer, bool& detectedTimeout)
+{
+	int32_t packetType;
+	packet >> packetType;
+
+	switch (packetType)
+	{
+	case Client::PlayerEvent:
+	{ 
+		int32_t identifier;
+		int32_t action;
+		packet >> identifier >> action;
+
+		nofifyPlayerEvent(identifier, action);
+
+		std::cout << "Server Received Client::PlayerEvent\n";
+	} break;
+
+	case Client::PlayerRealtimeChange:
+	{ 
+		int32_t identifier;
+		int32_t action;
+		bool actionEnabled;
+		packet >> identifier >> action >> actionEnabled;
+
+		mAircraftInfo[identifier].realtimeActions[action] = actionEnabled;
+		notifyPlayerRealtimeChange(identifier, action, actionEnabled, receivingPeer);
+
+		std::cout << "Server Received Client::PlayerRealtimeChange\n";
+	} break;
+
+	case Client::RequestCoopPartner:
+	{ 
+		// Set up data
+		mAircraftInfo[mAircraftIdentifierCounter].position = mBattleFieldRect.getCenter();
+		mAircraftInfo[mAircraftIdentifierCounter].hitpoints = 100;
+		mAircraftInfo[mAircraftIdentifierCounter].missileAmmo = 2;
+
+		receivingPeer.aircraftIdentifiers.push_back(mAircraftIdentifierCounter);
+
+		// Network to the peer that requested 
+		sf::Packet acceptPacket;
+		acceptPacket << static_cast<int32_t> (Server::AcceptCoopPartner);
+		acceptPacket << mAircraftIdentifierCounter
+			<< mAircraftInfo[mAircraftIdentifierCounter].position.x
+			<< mAircraftInfo[mAircraftIdentifierCounter].position.y;
+		receivingPeer.socket.send(acceptPacket);
+
+		// Network to the other peers
+		sf::Packet connectPacket;
+		connectPacket << static_cast<int32_t> (Server::PlayerConnect);
+		connectPacket << mAircraftIdentifierCounter
+			<< mAircraftInfo[mAircraftIdentifierCounter].position.x
+			<< mAircraftInfo[mAircraftIdentifierCounter].position.y;
+
+		for (PeerPtr& peer : mPeers)
+		{
+			if (peer->ready && 
+				peer.get() != &receivingPeer)
+			{
+				peer->socket.send(connectPacket);
+			}
+		}
+
+		// Finalize global state update
+		++mAircraftIdentifierCounter;
+		++mAircraftCount;
+
+		std::cout << "Server Received Client::RequestCoopPartner\n";
+	} break;
+
+	case Client::PositionUpdate:
+	{ 
+		int32_t numAircrafts;
+		packet >> numAircrafts;
+
+		int32_t identifier;
+		for (int32_t i = 0; i < numAircrafts; ++i)
+		{ // Should validate before storing
+			packet >> identifier;
+			packet >> mAircraftInfo[identifier].position.x 
+				>> mAircraftInfo[identifier].position.y
+				>> mAircraftInfo[identifier].hitpoints
+				>> mAircraftInfo[identifier].missileAmmo;
+		}
+	} break;
+
+	case Client::GameEvent:
+	{ 
+		int32_t type;
+		sf::Vector2f position;
+		packet >> type >> position.x >> position.y;
+
+		// Avoid sending multiple pickups by checking receivingPeer
+		if (type == GameActions::EnemyExplode && rand() % 3 == 0 &&
+			&receivingPeer == mPeers[0].get())
+		{
+			sf::Packet pickupPacket;
+			pickupPacket << static_cast<int32_t> (Server::SpawnPickup)
+				<< static_cast<int32_t> (rand() % Pickup::TypeCount)
+				<< position.x << position.y;
+
+			sendToAll(pickupPacket);
+		}
+
+		std::cout << "Server Received Client::GameEvent\n";
+	} break;
+
+	case Client::Quit:
+	{ 
+		receivingPeer.timedOut = true;
+		detectedTimeout = true;
+
+		std::cout << "Server Received Client::Quit\n";
+	} break;
+
+	default:
+	{ 
+	} break;
+	}
+}
+
+void GameServer::handleIncomingConnections()
+{
+	if (!mListeningState)
+	{
+		return;
+	}
+
+	// mListenerSocket is used for incoming connections from players
+	if (mListenerSocket.accept(mPeers[mConnectedPlayers]->socket)
+		== sf::TcpListener::Status::Done)
+	{
+		mAircraftInfo[mAircraftIdentifierCounter].position = mBattleFieldRect.getCenter();
+		mAircraftInfo[mAircraftIdentifierCounter].hitpoints = 100;
+		mAircraftInfo[mAircraftIdentifierCounter].missileAmmo = 2;
+
+		// Prepare SpawnSelf
+		sf::Packet packet;
+		packet << static_cast<int32_t> (Server::SpawnSelf);
+		packet << mAircraftIdentifierCounter;
+		packet << mAircraftInfo[mAircraftIdentifierCounter].position.x;
+		packet << mAircraftInfo[mAircraftIdentifierCounter].position.y;
+
+		mPeers[mConnectedPlayers]->aircraftIdentifiers.push_back(mAircraftIdentifierCounter);
+
+		// Broadcast message
+		broadcastMessage("New Player!");
+
+		// InitialState
+		informWorldState(mPeers[mConnectedPlayers]->socket);
+
+		// PlayerConnect
+		notifyPlayerSpawn(mAircraftIdentifierCounter++);
+
+		// SpawnSelf
+		mPeers[mConnectedPlayers]->socket.send(packet);
+
+		// Update connection info
+		mPeers[mConnectedPlayers]->ready = true;
+		mPeers[mConnectedPlayers]->lastPacketTime = now();
+
+		mAircraftCount++;
+		mConnectedPlayers++;
+		
+		if (mConnectedPlayers < mMaxConnectedPlayers)
+		{
+			mPeers.push_back(PeerPtr(new RemotePeer()));
+		}
+		else
+		{
+			setListening(false);
+		}
+	}
+}
+
+void GameServer::handleDisconnections()
+{ 
+	for (auto itr = mPeers.begin(); itr != mPeers.end();)
+	{
+		PeerPtr& peer = *itr;
+		if (peer->timedOut)
+		{
+			for (int32_t aircraftIdentifier : peer->aircraftIdentifiers)
+			{
+				sf::Packet packet;
+				packet << static_cast<int32_t> (Server::PlayerDisconnect)
+					<< aircraftIdentifier;
+
+				sendToAll(packet);
+
+				mAircraftInfo.erase(aircraftIdentifier);
+			}
+
+			if (mConnectedPlayers == mMaxConnectedPlayers)
+			{
+				setListening(true);
+			}
+
+			--mConnectedPlayers;
+			mAircraftCount -= peer->aircraftIdentifiers.size();
+
+			itr = mPeers.erase(itr);
+
+			broadcastMessage("An ally has disconnected.");
+		}
+		else
+		{
+			++itr;
+		}
+	}
+}
+
+void GameServer::informWorldState(sf::TcpSocket& socket)
+{  
+	sf::Packet packet;
+	packet << static_cast<int32_t> (Server::InitialState);
+	// Sends the how total distance and the bottom y of the page
+	packet << mWorldHeight << mBattleFieldRect.position.y + mBattleFieldRect.size.y;
+	packet << static_cast<int32_t> (mAircraftCount);
+
+	for (PeerPtr& peer : mPeers)
+	{
+		if (peer->ready)
+		{
+			for (int32_t identifier : peer->aircraftIdentifiers)
+			{
+				packet << identifier;
+				packet << mAircraftInfo[identifier].position.x
+					<< mAircraftInfo[identifier].position.y
+					<< mAircraftInfo[identifier].hitpoints
+					<< mAircraftInfo[identifier].missileAmmo;
+			}
+		}
+	}
+
+	socket.send(packet);
+}
+
+void GameServer::broadcastMessage(const std::string& message)
+{ 
+	sf::Packet packet;
+	packet << static_cast<int32_t> (Server::BroadcastMessage);
+	packet << message;
+	
+	sendToAll(packet);
+}
+
+void GameServer::sendToAll(sf::Packet& packet)
+{ 
+	for (PeerPtr& peer : mPeers)
+	{
+		if (peer->ready)
+		{
+			peer->socket.send(packet);
+		}
+	}
+}
+
+void GameServer::updateClientState()
+{
+	sf::Packet packet;
+	packet << static_cast<int32_t> (Server::UpdateClientState)
+		<< static_cast<float> (mBattleFieldRect.position.y + mBattleFieldRect.size.y)
+		<< static_cast<int32_t> (mAircraftInfo.size());
+
+	for (auto pair : mAircraftInfo)
+	{
+		packet << pair.first << pair.second.position.x << pair.second.position.y;
+	}
+
+	sendToAll(packet);
+}

--- a/Sfml-Game-Development/Source/GameState.cpp
+++ b/Sfml-Game-Development/Source/GameState.cpp
@@ -6,9 +6,10 @@
 
 GameState::GameState(StateStack& stack, Context context)
 	: State(stack, context)
-	, mWorld(*context.window, *context.fonts, *context.sounds)
-	, mPlayer(*context.player)
+	, mWorld(*context.window, *context.fonts, *context.sounds, false)
+	, mPlayer(nullptr, 1, context.keys1)
 {
+	mWorld.addAircraft(1);
 	mPlayer.setMissionStatus(Player::MissionRunning);
 
 	context.music->play(Music::ID::MissionTheme);
@@ -23,16 +24,16 @@ bool GameState::update(sf::Time dt)
 {
 	mWorld.update(dt);
 
-	if (mWorld.hasPlayerReachedEnd())
-	{
-		mPlayer.setMissionStatus(Player::MissionSuccess);
-		requestStackPush(States::GameOver);
-	}
-
 	if (!mWorld.hasAlivePlayer())
 	{
 		mPlayer.setMissionStatus(Player::MissionFailure);
 		requestStackPush(States::GameOver);
+	}
+
+	if (mWorld.hasPlayerReachedEnd())
+	{
+		mPlayer.setMissionStatus(Player::MissionSuccess);
+		requestStackPush(States::MissionSuccess);
 	}
 
 	CommandQueue& commands = mWorld.getCommandQueue();

--- a/Sfml-Game-Development/Source/KeyBinding.cpp
+++ b/Sfml-Game-Development/Source/KeyBinding.cpp
@@ -1,0 +1,98 @@
+#include "../Header/KeyBinding.h"
+
+KeyBinding::KeyBinding(int controlPreconfiguration)
+	: mKeyMap()
+{
+	if (controlPreconfiguration == 1)
+	{
+		mKeyMap[sf::Keyboard::Key::Left] = PlayerAction::MoveLeft;
+		mKeyMap[sf::Keyboard::Key::Right] = PlayerAction::MoveRight;
+		mKeyMap[sf::Keyboard::Key::Up] = PlayerAction::MoveUp;
+		mKeyMap[sf::Keyboard::Key::Down] = PlayerAction::MoveDown;
+		mKeyMap[sf::Keyboard::Key::Space] = PlayerAction::Fire;
+		mKeyMap[sf::Keyboard::Key::M] = PlayerAction::LaunchMissile;
+	}
+	else if (controlPreconfiguration == 2)
+	{
+		mKeyMap[sf::Keyboard::Key::A] = PlayerAction::MoveLeft;
+		mKeyMap[sf::Keyboard::Key::D] = PlayerAction::MoveRight;
+		mKeyMap[sf::Keyboard::Key::W] = PlayerAction::MoveUp;
+		mKeyMap[sf::Keyboard::Key::S] = PlayerAction::MoveDown;
+		mKeyMap[sf::Keyboard::Key::F] = PlayerAction::Fire;
+		mKeyMap[sf::Keyboard::Key::R] = PlayerAction::LaunchMissile;
+	}
+}
+
+void KeyBinding::assignKey(Action action, sf::Keyboard::Key key)
+{ // mKeyMap has a unique pairing
+	for (auto itr = mKeyMap.begin(); itr != mKeyMap.end();)
+	{
+		if (itr->second == action)
+		{
+			itr = mKeyMap.erase(itr);
+		}
+		else
+		{
+			++itr;
+		}
+	}
+
+	mKeyMap[key] = action;
+}
+
+sf::Keyboard::Key KeyBinding::getAssignedKey(Action action) const
+{
+	for (auto& pair : mKeyMap)
+	{
+		if (pair.second == action)
+		{
+			return pair.first;
+		}
+	}
+
+	return sf::Keyboard::Key::Unknown;
+}
+
+bool KeyBinding::checkAction(sf::Keyboard::Key key, Action& out) const
+{ // isActionValid
+	auto found = mKeyMap.find(key);
+	if (found == mKeyMap.end())
+	{
+		return false;
+	}
+	else
+	{
+		out = found->second;
+		return true;
+	}
+}
+
+std::vector<KeyBinding::Action> KeyBinding::getRealtimeActions() const
+{
+	std::vector<Action> actions;
+	for (auto &pair : mKeyMap)
+	{
+		if (sf::Keyboard::isKeyPressed(pair.first) && isRealtimeAction(pair.second))
+		{
+			actions.push_back(pair.second);
+		}
+	}
+
+	return actions;
+}
+
+bool isRealtimeAction(PlayerAction::Type action)
+{
+	switch (action)
+	{
+	case PlayerAction::MoveLeft:
+	case PlayerAction::MoveRight:
+	case PlayerAction::MoveUp:
+	case PlayerAction::MoveDown:
+	case PlayerAction::Fire:
+		return true;
+
+	default:
+		return false;
+	}
+}

--- a/Sfml-Game-Development/Source/MenuState.cpp
+++ b/Sfml-Game-Development/Source/MenuState.cpp
@@ -12,7 +12,7 @@ MenuState::MenuState(StateStack& stack, Context context)
 	, mGUIContainer()
 {
 	auto playButton = std::make_shared<GUI::Button>(context);
-	playButton->setPosition({ 100, 250 });
+	playButton->setPosition({ 100, 300 });
 	playButton->setText("Play");
 	playButton->setCallback([this] () 
 	{
@@ -20,8 +20,25 @@ MenuState::MenuState(StateStack& stack, Context context)
 		requestStackPush(States::Game);
 	});
 
+	auto hostButton = std::make_shared<GUI::Button>(context);
+	hostButton->setPosition({ 100, 350 });
+	hostButton->setText("Host");
+	hostButton->setCallback([this]() {
+		requestStackPop();
+		requestStackPush(States::HostGame);
+		});
+
+	auto joinButton = std::make_shared<GUI::Button>(context);
+	joinButton->setPosition({ 100, 400 });
+	joinButton->setText("Join");
+	joinButton->setCallback([this]() {
+		requestStackPop();
+		requestStackPush(States::JoinGame);
+		});
+
+
 	auto settingsButton = std::make_shared<GUI::Button>(context);
-	settingsButton->setPosition({ 100, 300 });
+	settingsButton->setPosition({ 100, 450 });
 	settingsButton->setText("Settings");
 	settingsButton->setCallback([this]()
 	{
@@ -29,7 +46,7 @@ MenuState::MenuState(StateStack& stack, Context context)
 	});
 
 	auto exitButton = std::make_shared<GUI::Button>(context);
-	exitButton->setPosition({ 100, 350 });
+	exitButton->setPosition({ 100, 500 });
 	exitButton->setText("Exit");
 	exitButton->setCallback([this]()
 	{
@@ -37,6 +54,8 @@ MenuState::MenuState(StateStack& stack, Context context)
 	});
 
 	mGUIContainer.pack(playButton);
+	mGUIContainer.pack(hostButton);
+	mGUIContainer.pack(joinButton);
 	mGUIContainer.pack(settingsButton);
 	mGUIContainer.pack(exitButton);
 

--- a/Sfml-Game-Development/Source/MultiplayerGameState.cpp
+++ b/Sfml-Game-Development/Source/MultiplayerGameState.cpp
@@ -1,0 +1,568 @@
+#include "../Header/MultiplayerGameState.h"
+#include "../Header/MusicPlayer.h"
+#include "../Header/Utility.hpp"
+
+#include <SFML/Network/IpAddress.hpp>
+#include <fstream>
+#include <iostream>
+
+
+sf::IpAddress getAddressFromFile()
+{
+	{ // RAII block to open existing file
+		std::ifstream inputFile("ip.txt");
+		std::string ipAddress;
+		if (inputFile >> ipAddress)
+		{
+			auto address = sf::IpAddress::resolve(ipAddress);
+			if (address.has_value())
+			{
+				return address.value();
+			}
+		}
+	}
+
+	std::ofstream outputFile("ip.txt");
+	std::string localAddress = "127.0.0.1";
+	outputFile << localAddress;
+	auto address = sf::IpAddress::resolve(localAddress);
+	return address.value();
+}
+
+sf::IpAddress toIpAddress(const std::string& address)
+{
+	auto ipAddress = sf::IpAddress::resolve(address);
+	if (ipAddress.has_value())
+	{
+		return ipAddress.value();
+	}
+}
+
+MultiplayerGameState::MultiplayerGameState(StateStack& stack, Context context, bool isHost)
+	: State(stack, context)
+	, mWorld(*context.window, *context.fonts, *context.sounds, true) 
+	, mWindow(*context.window)
+	, mTextureHolder(*context.textures)
+	, mPlayers()
+	, mLocalPlayerIdentifiers()
+	, mSocket()
+	, mConnected(false)
+	, mGameServer(nullptr)
+	, mTickClock()
+	, mBroadcasts()
+	, mBroadcastText(context.fonts->get(Fonts::ID::Sansation))
+	, mBroadcastElapsedTime(sf::Time::Zero)
+	, mPlayerInvitationText(context.fonts->get(Fonts::ID::Sansation),
+		"Press Enter to spawn player 2", 20)
+	, mPlayerInvitationTime(sf::Time::Zero)
+	, mFailedConnectionText(context.fonts->get(Fonts::ID::Sansation),
+		"Attempting to connect...", 35)
+	, mFailedConnectionClock()
+	, mActiveState(true)
+	, mHasFocus(true)
+	, mHost(isHost)
+	, mGameStarted(false)
+	, mClientTimeout(sf::seconds(2.f))
+	, mTimeSinceLastPacket(sf::seconds(0.f))
+{
+	mBroadcastText.setPosition({ 1024.f / 2, 100.f });
+
+	mPlayerInvitationText.setFillColor(sf::Color::White);
+	mPlayerInvitationText.setPosition({ 1000 - mPlayerInvitationText.getLocalBounds().size.x,
+		700 - mPlayerInvitationText.getLocalBounds().size.y });
+
+	mFailedConnectionText.setFillColor(sf::Color::White);
+	centerOrigin(mFailedConnectionText);
+	mFailedConnectionText.setPosition({ mWindow.getSize().x / 2.f , 
+		mWindow.getSize().y / 2.f });
+
+	mWindow.clear(sf::Color::Black);
+	mWindow.draw(mFailedConnectionText);
+	mWindow.display();
+
+	mFailedConnectionText.setString("Could not connect to the remote server!");
+	centerOrigin(mFailedConnectionText);
+
+	sf::IpAddress ip (127, 0, 0, 1);
+	if (isHost)
+	{
+		mGameServer.reset(new GameServer(
+			sf::Vector2f({ static_cast<float> (mWindow.getSize().x)
+			, static_cast<float> (mWindow.getSize().y) })));
+	}
+	else
+	{
+		ip = getAddressFromFile();
+	}
+
+	if (mSocket.connect(ip, ServerPort, sf::seconds(5.f)) == sf::TcpSocket::Status::Done)
+	{
+		mConnected = true;
+	}
+	else
+	{
+		mFailedConnectionClock.restart();
+	}
+
+	mSocket.setBlocking(false);
+
+	context.music->play(Music::ID::MissionTheme);
+}
+
+void MultiplayerGameState::draw()
+{ 
+	if (mConnected)
+	{
+		mWorld.draw();
+
+		mWindow.setView(mWindow.getDefaultView());
+		if (!mBroadcasts.empty())
+		{
+			mWindow.draw(mBroadcastText);
+		}
+		if (mLocalPlayerIdentifiers.size() < 2 && mPlayerInvitationTime < sf::seconds(0.5f))
+		{
+			mWindow.draw(mPlayerInvitationText);
+		}
+	}
+	else
+	{
+		mWindow.draw(mFailedConnectionText);
+	}
+}
+
+bool MultiplayerGameState::update(sf::Time dt)
+{ 
+	if (mConnected)
+	{
+		mWorld.update(dt);
+
+		bool foundLocalPlane = false;
+		for (auto itr = mPlayers.begin(); itr != mPlayers.end();)
+		{
+			if (!mWorld.getAircraft(itr->first))
+			{
+				itr = mPlayers.erase(itr);
+
+				if (mPlayers.empty())
+				{ // No players left
+					requestStackPush(States::GameOver);
+				}
+			}
+			else
+			{
+				if (std::find(mLocalPlayerIdentifiers.begin(), mLocalPlayerIdentifiers.end(),
+					itr->first) != mLocalPlayerIdentifiers.end())
+				{ // Local players are never removed
+					foundLocalPlane = true;
+				}
+
+				++itr;
+			}
+		}
+
+		if (!foundLocalPlane && mGameStarted)
+		{ // No local player left
+			requestStackPush(States::GameOver);
+		}
+
+		// Only handle local realtime input if the player is playing
+		CommandQueue& commands = mWorld.getCommandQueue();
+		if (mActiveState && mHasFocus)
+		{
+			for (auto& pair : mPlayers)
+			{
+				pair.second->handleRealtimeInput(commands);
+			}
+		}
+
+		// Always handle remote realtime input
+		for (auto& pair : mPlayers)
+		{
+			pair.second->handleRealtimeNetworkInput(commands);
+		}
+
+		sf::Packet packet;
+		if (mSocket.receive(packet) == sf::TcpSocket::Status::Done)
+		{ 
+			mTimeSinceLastPacket = sf::Time::Zero;
+
+			int32_t packetType;
+			packet >> packetType;
+			handlePacket(packetType, packet);
+		}
+		else if (mClientTimeout < mTimeSinceLastPacket)
+		{ // No retry happens
+			mConnected = false;
+
+			mFailedConnectionText.setString("Lost connection to server");
+			centerOrigin(mFailedConnectionText);
+
+			mFailedConnectionClock.restart();
+		}
+
+		updateBroadcastMessage(dt);
+
+		// Preventing overflow for player invitation text that blinks every half second 
+		mPlayerInvitationTime += dt;
+		if (mPlayerInvitationTime > sf::seconds(1.f))
+		{
+			mPlayerInvitationTime = sf::Time::Zero;
+		}
+
+		// Destroyed an enemy
+		GameActions::Action gameAction;
+		while (mWorld.pollGameAction(gameAction))
+		{
+			sf::Packet packet;
+			packet << static_cast<int32_t> (Client::GameEvent);
+			packet << static_cast<int32_t> (gameAction.type);
+			packet << gameAction.position.x << gameAction.position.y;
+
+			mSocket.send(packet);
+		}
+
+		// Sending constant position update to the server
+		if (mTickClock.getElapsedTime() > sf::seconds(1.f / 20.f))
+		{
+			sf::Packet positionUpdatePacket;
+			positionUpdatePacket << static_cast<int32_t> (Client::PositionUpdate);
+			positionUpdatePacket << static_cast<int32_t> (mLocalPlayerIdentifiers.size());
+			for (int32_t identifier : mLocalPlayerIdentifiers)
+			{
+				if (Aircraft* aircraft = mWorld.getAircraft(identifier))
+				{
+					positionUpdatePacket << identifier
+						<< aircraft->getPosition().x << aircraft->getPosition().y
+						<< static_cast<int32_t> (aircraft->getHitpoints())
+						<< static_cast<int32_t> (aircraft->getMissileAmmo());
+				}
+			} 
+
+			mSocket.send(positionUpdatePacket);
+
+			mTickClock.restart();
+		}
+
+		mTimeSinceLastPacket += dt;
+	}
+	else if (sf::seconds(5.f) < mFailedConnectionClock.getElapsedTime())
+	{
+		requestStateClear();
+		requestStackPush(States::Menu);
+	}
+
+	return true;
+}
+
+bool MultiplayerGameState::handleEvent(const sf::Event& event)
+{ // Both realtime network change and event relies on handleEvent
+	CommandQueue commands = mWorld.getCommandQueue();
+
+	for (auto& pair : mPlayers)
+	{ // Player's handleEvent only processes local events
+		pair.second->handleEvent(event, commands);
+	}
+
+	if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
+	{
+		if (keyPressed->code == sf::Keyboard::Key::Enter
+			&& mLocalPlayerIdentifiers.size() == 1)
+		{
+			sf::Packet packet;
+			packet << static_cast<int32_t> (Client::RequestCoopPartner);
+
+			mSocket.send(packet);
+		}
+
+		if (keyPressed->code == sf::Keyboard::Key::Escape)
+		{
+			// Real-time actions are disabled even if keys are pressed
+			disableAllRealtimeActions();
+			requestStackPush(States::NetworkPause);
+		}
+	} 
+	else if (event.is<sf::Event::FocusGained>())
+	{
+		mHasFocus = true;
+	}
+	else if (event.is<sf::Event::FocusLost>())
+	{
+		mHasFocus = false;
+	}
+
+	return true;
+}
+
+void MultiplayerGameState::onActivate()
+{ // StateStack's applyPendingChanges calls it after NetworkPause
+	mActiveState = true;
+}
+
+void MultiplayerGameState::onDestroy()
+{ // Used in StateStack's applyPendingChanges
+	if (!mHost && mConnected)
+	{
+		sf::Packet packet;
+		packet << static_cast<int32_t> (Client::Quit);
+
+		mSocket.send(packet);
+	}
+}
+
+void MultiplayerGameState::disableAllRealtimeActions()
+{ 
+	mActiveState = false;
+
+	for (int32_t localIdentifier : mLocalPlayerIdentifiers)
+	{
+		mPlayers[localIdentifier]->disableAllRealtimeActions();
+	}
+}
+
+void MultiplayerGameState::updateBroadcastMessage(sf::Time elapsedTime)
+{ 
+	if (mBroadcasts.empty())
+	{
+		return;
+	}
+
+	mBroadcastElapsedTime += elapsedTime;
+
+	if (mBroadcastElapsedTime > sf::seconds(2.5f))
+	{
+		mBroadcasts.erase(mBroadcasts.begin());
+
+		std::string next;
+		if (!mBroadcasts.empty())
+		{
+			next = mBroadcasts.front();
+			mBroadcastElapsedTime = sf::Time::Zero;
+		}
+
+		mBroadcastText.setString(next);
+		centerOrigin(mBroadcastText);
+	}
+}
+
+void MultiplayerGameState::handlePacket(int32_t packetType, sf::Packet& packet)
+{
+	switch (packetType)
+	{
+	case Server::BroadcastMessage:
+	{
+		std::string message;
+		packet >> message;
+		mBroadcasts.push_back(message);
+
+		if (mBroadcasts.size() == 1)
+		{
+			mBroadcastText.setString(mBroadcasts.front());
+			centerOrigin(mBroadcastText);
+			mBroadcastElapsedTime = sf::Time::Zero;
+		}
+
+		std::cout << "Client Received Server::BroadcastMessage\n";
+	} break;
+
+	case Server::SpawnSelf:
+	{
+		int32_t aircraftIdentifier;
+		sf::Vector2f aircraftPosition;
+		packet >> aircraftIdentifier >> aircraftPosition.x >> aircraftPosition.y;
+
+		Aircraft* aircraft = mWorld.addAircraft(aircraftIdentifier);
+		aircraft->setPosition(aircraftPosition);
+
+		mPlayers[aircraftIdentifier].reset(
+			new Player(&mSocket, aircraftIdentifier, getContext().keys1));
+		mLocalPlayerIdentifiers.push_back(aircraftIdentifier);
+
+		mGameStarted = true;
+
+		std::cout << "Client Received Server::SpawnSelf\n";
+	} break;
+
+	case Server::PlayerConnect:
+	{	
+		int32_t aircraftIdentifier;
+		sf::Vector2f aircraftPosition;
+		packet >> aircraftIdentifier >> aircraftPosition.x >> aircraftPosition.y;
+
+		Aircraft* aircraft = mWorld.addAircraft(aircraftIdentifier);
+		aircraft->setPosition(aircraftPosition);
+
+		// Remote player doesn't send packet, socket is redundant
+		mPlayers[aircraftIdentifier].reset(
+			new Player(nullptr, aircraftIdentifier, nullptr));
+
+		std::cout << "Client Received Server::PlayerConnect\n";
+	}	break;
+
+	case Server::PlayerDisconnect:
+	{	
+		int32_t aircraftIdentifier;
+		packet >> aircraftIdentifier;
+
+		mWorld.removeAircraft(aircraftIdentifier);
+		mPlayers.erase(aircraftIdentifier);
+
+		std::cout << "Client Received Server::PlayerDisconnect\n";
+	}	break;
+
+	case Server::InitialState:
+	{ 
+		float worldHeight;
+		float initialScrolling;
+		packet >> worldHeight >> initialScrolling;
+		mWorld.setWorldHeight(worldHeight);
+		mWorld.setCurrentBattleFieldPosition(initialScrolling);
+
+		int32_t aircraftCount;
+		packet >> aircraftCount;
+		for (int32_t i = 0; i < aircraftCount; ++i)
+		{ // Setting remote aircrafts
+			int32_t aircraftIdentifier;
+			sf::Vector2f aircraftPosition;
+			int32_t aircraftHitpoints = 0;
+			int32_t aircraftMissileAmmo = 0;
+
+			packet >> aircraftIdentifier >> aircraftPosition.x >> aircraftPosition.y
+				>> aircraftHitpoints >> aircraftMissileAmmo;
+
+			Aircraft* aircraft = mWorld.addAircraft(aircraftIdentifier);
+			aircraft->setPosition(aircraftPosition);
+			aircraft->setHitpoints(aircraftHitpoints);
+			aircraft->setMissileAmmo(aircraftMissileAmmo);
+
+			mPlayers[aircraftIdentifier].reset(
+				new Player(&mSocket, aircraftIdentifier, nullptr));
+		}
+
+		std::cout << "Client Received Server::InitialState\n";
+	}	break;
+
+	case Server::PlayerEvent:
+	{	
+		int32_t identifier;
+		int32_t action;
+		packet >> identifier >> action;
+
+		CommandQueue& commands = mWorld.getCommandQueue();
+		auto itr = mPlayers.find(identifier);
+		if (itr != mPlayers.end())
+		{
+			itr->second->handleNetworkEvent(
+				static_cast<Player::Action> (action), commands);
+		}
+
+		std::cout << "Client Received Server::PlayerEvent\n";
+	}	break;
+
+	case Server::PlayerRealtimeChange:
+	{	
+		int32_t aircraftIdentifier;
+		int32_t action;
+		bool actionEnabled;
+
+		packet >> aircraftIdentifier >> action >> actionEnabled;
+
+		auto itr = mPlayers.find(aircraftIdentifier);
+		if (itr != mPlayers.end())
+		{
+			itr->second->handleNetworkRealtimeChange(static_cast<Player::Action> (action),
+				actionEnabled);
+		}
+
+		std::cout << "Client Received Server::PlayerRealtimeChange\n";
+	}	break;
+
+	case Server::AcceptCoopPartner:
+	{	
+		int32_t aircraftIdentifier;
+		sf::Vector2f aircraftPosition;
+		packet >> aircraftIdentifier >> aircraftPosition.x >> aircraftPosition.y;
+
+		Aircraft* aircraft = mWorld.addAircraft(aircraftIdentifier);
+		aircraft->setPosition(aircraftPosition);
+
+		mPlayers[aircraftIdentifier].reset(
+			new Player(&mSocket, aircraftIdentifier, getContext().keys2));
+		mLocalPlayerIdentifiers.push_back(aircraftIdentifier);
+
+		std::cout << "Client Received Server::AcceptCoopPartner\n";
+	}	break;
+
+	case Server::SpawnEnemy:
+	{	
+		int32_t type;
+		float height;
+		float relativeX;
+		packet >> type >> height >> relativeX;
+
+		mWorld.addEnemy(static_cast<Aircraft::Type> (type), relativeX, height);
+		mWorld.sortEnemies();
+
+		std::cout << "Client Received Server::SpawnEnemy\n";
+	}	break;
+
+	case Server::MissionSuccess:
+	{
+		requestStackPush(States::MissionSuccess);
+
+		std::cout << "Client Received Server::MissionSuccess\n";
+	}	break;
+
+	case Server::SpawnPickup:
+	{	
+		int32_t type;
+		sf::Vector2f position;
+		packet >> type >> position.x >> position.y;
+
+		mWorld.createPickup(position, static_cast<Pickup::Type> (type));
+
+		std::cout << "Client Received Server::SpawnPickup\n";
+	}	break;
+
+	case Server::UpdateClientState:
+	{	
+		float currentWorldPosition;
+		int32_t aircraftCount;
+		packet >> currentWorldPosition >> aircraftCount;
+
+		float currentViewPosition = 
+			mWorld.getViewBounds().position.y + mWorld.getViewBounds().size.y;
+
+		/*
+		* If view > world, 
+		*	1.f + 0.001f * (currentViewPosition - currentWorldPosition) > 1
+		* If world > view,
+		*	1.f + 0.001f * (currentViewPosition - currentWorldPosition) < 1
+		*/
+		mWorld.setWorldScrollCompensation(
+			1.f + 0.001f * (currentViewPosition - currentWorldPosition));
+		
+		for (int32_t i = 0; i < aircraftCount; ++i)
+		{
+			int32_t identifier;
+			sf::Vector2f position;
+			packet >> identifier >> position.x >> position.y;
+			
+			Aircraft* aircraft = mWorld.getAircraft(identifier);
+			bool isLocalPlane = std::find(mLocalPlayerIdentifiers.begin(),
+				mLocalPlayerIdentifiers.end(), identifier) != mLocalPlayerIdentifiers.end();
+			if (aircraft && !isLocalPlane)
+			{
+				sf::Vector2f interpolatedPosition = aircraft->getPosition() + 
+					(position - aircraft->getPosition()) * 0.1f;
+				aircraft->setPosition(position);
+			}
+		}
+	}	break;
+	
+	default:
+	{
+	}	break;
+	}
+}
+

--- a/Sfml-Game-Development/Source/NetworkNode.cpp
+++ b/Sfml-Game-Development/Source/NetworkNode.cpp
@@ -1,0 +1,30 @@
+#include "../Header/NetworkNode.h"
+
+
+NetworkNode::NetworkNode()
+	: SceneNode()
+	, mPendingActions()
+{
+}
+
+void NetworkNode::notifyGameAction(GameActions::Type type, sf::Vector2f position)
+{
+	mPendingActions.push(GameActions::Action(type, position));
+}
+
+bool NetworkNode::pollGameAction(GameActions::Action& out)
+{
+	if (mPendingActions.empty())
+	{
+		return false;
+	}
+
+	out = mPendingActions.front();
+	mPendingActions.pop();
+	return true;
+}
+
+unsigned int NetworkNode::getCategory() const
+{
+	return Category::Network;
+}

--- a/Sfml-Game-Development/Source/PauseState.cpp
+++ b/Sfml-Game-Development/Source/PauseState.cpp
@@ -9,10 +9,11 @@
 #include <memory>
 
 
-PauseState::PauseState(StateStack& stack, Context context)
+PauseState::PauseState(StateStack& stack, Context context, bool letUpdatesThrough) 
 	: State(stack, context)
 	, mPauseText(context.fonts->get(Fonts::ID::Sansation))
 	, mGUIContainer()
+	, mLetUpdatesThrough(letUpdatesThrough) 
 { 
 	sf::Vector2f viewSize = context.window->getView().getSize();
 
@@ -63,9 +64,9 @@ void PauseState::draw()
 	window.draw(mGUIContainer);
 }
 
-bool PauseState::update(sf::Time dt)
-{
-	return false;
+bool PauseState::update(sf::Time)
+{ 
+	return mLetUpdatesThrough;
 }
 
 bool PauseState::handleEvent(const sf::Event& event)

--- a/Sfml-Game-Development/Source/SettingsState.cpp
+++ b/Sfml-Game-Development/Source/SettingsState.cpp
@@ -10,12 +10,15 @@ SettingsState::SettingsState(StateStack& stack, Context context)
 	, mBackgroundSprite(context.textures->get(Textures::ID::TitleScreen))
 	, mGUIContainer()
 {
-	addButtonLabel(Player::MoveLeft, 300.f, "Move Left", context);
-	addButtonLabel(Player::MoveRight, 350.f, "Move Right", context);
-	addButtonLabel(Player::MoveUp, 400.f, "Move Up", context);
-	addButtonLabel(Player::MoveDown, 450.f, "Move Down", context);
-	addButtonLabel(Player::Fire, 500.f, "Fire", context);
-	addButtonLabel(Player::LaunchMissile, 550.f, "Missile", context);
+	for (size_t player = 0; player < 2; ++player)
+	{
+		addButtonLabel(PlayerAction::MoveLeft, player, 0, "Move Left", context);
+		addButtonLabel(PlayerAction::MoveRight, player, 1, "Move Right", context);
+		addButtonLabel(PlayerAction::MoveUp, player, 2, "Move Up", context);
+		addButtonLabel(PlayerAction::MoveDown, player, 3, "Move Down", context);
+		addButtonLabel(PlayerAction::Fire, player, 4, "Fire", context);
+		addButtonLabel(PlayerAction::LaunchMissile, player, 5, "Missile", context);
+	}
 
 	updateLabels();
 
@@ -43,19 +46,27 @@ bool SettingsState::update(sf::Time dt)
 
 bool SettingsState::handleEvent(const sf::Event& event)
 {
-	Player& player = *getContext().player;
-
 	bool isKeyBinding = false;
-	for (size_t action = 0; action < Player::ActionCount; ++action)
+	for (size_t button = 0; button < 2 * PlayerAction::Count; ++button)
 	{
-		if (mBindingButtons[action]->isActive())
+		if (mBindingButtons[button]->isActive())
 		{
 			isKeyBinding = true;
 			if (const auto* keyReleased = event.getIf<sf::Event::KeyReleased>())
 			{
-				getContext().player->assignKey(
-					static_cast<Player::Action>(action), keyReleased->code);
-				mBindingButtons[action]->deactivate();
+				if (button < PlayerAction::Count)
+				{
+					getContext().keys1->assignKey(
+						static_cast<PlayerAction::Type>(button), keyReleased->code);
+				}
+				else
+				{
+					getContext().keys2->assignKey(
+						static_cast<PlayerAction::Type>(button - PlayerAction::Count), 
+						keyReleased->code);
+				}
+				
+				mBindingButtons[button]->deactivate();
 			}
 			break;
 		}
@@ -75,25 +86,31 @@ bool SettingsState::handleEvent(const sf::Event& event)
 
 void SettingsState::updateLabels()
 {
-	Player& player = *getContext().player;
 
-	for (size_t i = 0; i < Player::ActionCount; ++i)
+	for (size_t button = 0; button < PlayerAction::Count; ++button)
 	{
-		sf::Keyboard::Key key = player.getAssignedKey(static_cast<Player::Action>(i));
-		mBindingLabels[i]->setText(toString(key));
+		auto action = static_cast<PlayerAction::Type>(button);
+		
+		sf::Keyboard::Key key1 = getContext().keys1->getAssignedKey(action);
+		sf::Keyboard::Key key2 = getContext().keys2->getAssignedKey(action);
+
+		mBindingLabels[button]->setText(toString(key1));
+		mBindingLabels[button + PlayerAction::Count]->setText(toString(key2));
 	}
 }
 
-void SettingsState::addButtonLabel(Player::Action action, float y, const std::string& text, Context context)
+void SettingsState::addButtonLabel(size_t index, size_t x, size_t y, const std::string& text, Context context)
 {
-	mBindingButtons[action] = std::make_shared<GUI::Button>(context);
-	mBindingButtons[action]->setPosition({ 80.f, y });
-	mBindingButtons[action]->setText(text);
-	mBindingButtons[action]->setToggle(true);
+	index += PlayerAction::Count * x;
 
-	mBindingLabels[action] = std::make_shared<GUI::Label>("",  * context.fonts);
-	mBindingLabels[action]->setPosition({ 300.f, y + 15.f });
+	mBindingButtons[index] = std::make_shared<GUI::Button>(context);
+	mBindingButtons[index]->setPosition({ 400.f * x + 80.f, 50.f * y + 300.f });
+	mBindingButtons[index]->setText(text);
+	mBindingButtons[index]->setToggle(true);
 
-	mGUIContainer.pack(mBindingButtons[action]);
-	mGUIContainer.pack(mBindingLabels[action]);
+	mBindingLabels[index] = std::make_shared<GUI::Label>("",  * context.fonts);
+	mBindingLabels[index]->setPosition({ 400.f * x + 300.f, 50.f * y + 315.f });
+
+	mGUIContainer.pack(mBindingButtons[index]);
+	mGUIContainer.pack(mBindingLabels[index]);
 }

--- a/Sfml-Game-Development/Source/SoundPlayer.cpp
+++ b/Sfml-Game-Development/Source/SoundPlayer.cpp
@@ -64,7 +64,7 @@ void SoundPlayer::play(SoundEffect::ID effect, sf::Vector2f position)
 	sound.play();
 }
 
-void SoundPlayer::removeSounds()
+void SoundPlayer::removeStoppedSounds()
 {
 	remove_if(mSounds.begin(), mSounds.end(), [](const sf::Sound& sound)
 		{

--- a/Sfml-Game-Development/Source/State.cpp
+++ b/Sfml-Game-Development/Source/State.cpp
@@ -3,13 +3,15 @@
 
 
 State::Context::Context(sf::RenderWindow& window, TextureHolder& textures,
-	FontHolder& fonts, Player& player, MusicPlayer& music, SoundPlayer& sounds)
+	FontHolder& fonts, MusicPlayer& music, SoundPlayer& sounds, 
+	KeyBinding& keys1, KeyBinding& keys2)
 	: window(&window)
 	, textures(&textures)
 	, fonts(&fonts)
-	, player(&player)
 	, music(&music)
 	, sounds(&sounds)
+	, keys1(&keys1)
+	, keys2(&keys2)
 {
 }
 
@@ -41,4 +43,12 @@ void State::requestStateClear()
 State::Context State::getContext() const
 {
 	return mContext;
+}
+
+void State::onActivate()
+{
+}
+
+void State::onDestroy()
+{
 }

--- a/Sfml-Game-Development/Source/StateStack.cpp
+++ b/Sfml-Game-Development/Source/StateStack.cpp
@@ -33,19 +33,6 @@ void StateStack::draw()
 
 void StateStack::handleEvent(const sf::Event& event)
 {
-	if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
-	{
-		if (keyPressed->code == sf::Keyboard::Key::Z)
-		{
-			
-			mContext.music->setVolume(mContext.music->getVolume() - 1);
-		}
-		else if (keyPressed->code == sf::Keyboard::Key::X)
-		{
-
-			mContext.music->setVolume(mContext.music->getVolume() + 1);
-		}
-	}
 	for (auto itr = mStack.rbegin(); itr != mStack.rend(); ++itr)
 	{
 		if (!(*itr)->handleEvent(event))
@@ -92,16 +79,36 @@ void StateStack::applyPendingChanges()
 		switch (change.action)
 		{
 		case Push:
+			if (!mStack.empty())
+			{
+				mStack.back()->onDestroy();
+			}
+
 			mStack.push_back(createState(change.stateID));
+			mStack.back()->onActivate();
 			break;
 		case Pop:
+			assert(!mStack.empty());
+
+			mStack.back()->onDestroy();
 			mStack.pop_back();
+			if (!mStack.empty())
+			{
+				mStack.back()->onActivate();
+			}
+
 			break;
 		case Clear:
-			mStack.clear();
+			while (!mStack.empty())
+			{
+				mStack.back()->onDestroy();
+				mStack.pop_back();
+			}
+
 			break;
 		}
 	}
+
 
 	mPendingList.clear();
 }

--- a/Sfml-Game-Development/Source/StateStack.cpp
+++ b/Sfml-Game-Development/Source/StateStack.cpp
@@ -79,11 +79,6 @@ void StateStack::applyPendingChanges()
 		switch (change.action)
 		{
 		case Push:
-			if (!mStack.empty())
-			{
-				mStack.back()->onDestroy();
-			}
-
 			mStack.push_back(createState(change.stateID));
 			mStack.back()->onActivate();
 			break;


### PR DESCRIPTION
 # Description
- Using a socket, every client (MultiplayerGameState)  joins and communicates with the server  (GameServer)
- Every client sends its action to the server using a packet defined in NetworkProtocol.h
- The server receives the action and send its authorized request to sync all the clients
- The client performs all real-time actions without the server's packet

# Highlight
- Player sends real-time network events using event to reliably send when the event occurred and ended
- The client corrects its view and its aircrafts' speed based on the server's authorized position

# Room for improvement
- The server should verify every client action and track every enemy, bullet, and missile and simulate using the World (The server should let the client know whether the enemy is destroyed)
- The server should send additional packet that let the client know all their aircrafts are destroyed but allow them to watch the remaining game
- Have separate implementation for adding the enemies in the networked World for better readability

# How To Run
- Fix the port number in NetworkProtocol.h if it is already used
- Find the server's IP address and record it in ip.txt
- Run the host and clients